### PR TITLE
Make the creation of simd kernels unsafe

### DIFF
--- a/benches/gemm_f32.rs
+++ b/benches/gemm_f32.rs
@@ -22,7 +22,7 @@ fn bench_gemm(criterion: &mut Criterion) {
 
     #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
-        let kernel = &mg::kernels::NeonKernel::<f32>::new();
+        let kernel = unsafe { &mg::kernels::NeonKernel::<f32>::new() };
         bench_kernel_with(group, "neon-kernel", kernel, mkn, pack_sizes);
     }
 

--- a/examples/wasm_simd128/src/main.rs
+++ b/examples/wasm_simd128/src/main.rs
@@ -1,8 +1,14 @@
+#![cfg(target_arch = "wasm32")]
+
 use microgemm as mg;
 use microgemm::Kernel as _;
 
 fn main() {
-    let kernel = mg::kernels::WasmSimd128Kernel::<f32>::new();
+    let kernel = if cfg!(target_feature = "simd128") {
+        unsafe { mg::kernels::WasmSimd128Kernel::<f32>::new() }
+    } else {
+        panic!("simd128 target feature is not enabled");
+    };
     assert_eq!(kernel.mr(), 4);
     assert_eq!(kernel.nr(), 4);
 

--- a/src/kernels/mod.rs
+++ b/src/kernels/mod.rs
@@ -1,13 +1,13 @@
 mod generic;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(target_arch = "aarch64")]
 mod neon;
-#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[cfg(target_arch = "wasm32")]
 mod wasm;
 
 pub use generic::{
     Generic16x16Kernel, Generic2x2Kernel, Generic32x32Kernel, Generic4x4Kernel, Generic8x8Kernel,
 };
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(target_arch = "aarch64")]
 pub use neon::NeonKernel;
-#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[cfg(target_arch = "wasm32")]
 pub use wasm::WasmSimd128Kernel;


### PR DESCRIPTION
Allows more flexible use of simd kernels with target feature detection both at runtime and compile time